### PR TITLE
Fix TypeORM entity discovery for business locations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { SchedulingModule } from './modules/scheduling/scheduling.module';
         username: configService.get<string>('DB_USER'),
         password: configService.get<string>('DB_PASS'),
         database: configService.get<string>('DB_NAME'),
+        entities: [__dirname + '/**/*.entity{.ts,.js}'],
         autoLoadEntities: true,
         synchronize: false,
         migrationsRun: false,


### PR DESCRIPTION
## Summary
- include an entities glob in the TypeORM configuration so all metadata, including BusinessLocation, is registered at startup

## Testing
- npm run lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc336b4f2483218c071e412f99e62d