### PR TITLE
Guard data-source path detection across module systems

### DIFF
--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -2,7 +2,39 @@ import 'dotenv/config';
 import { fileURLToPath } from 'node:url';
 import { DataSource } from 'typeorm';
 
-const currentFile = fileURLToPath(import.meta.url);
+const currentFile = (() => {
+  if (typeof __filename === 'string' && __filename.length > 0) {
+    return __filename;
+  }
+
+  if (typeof module !== 'undefined' && module?.filename) {
+    return module.filename;
+  }
+
+  try {
+    const importMetaUrl = eval('import.meta.url');
+    if (typeof importMetaUrl === 'string' && importMetaUrl.length > 0) {
+      return fileURLToPath(importMetaUrl);
+    }
+  } catch {
+    // import.meta is not directly accessible in this environment
+  }
+
+  const stack = new Error().stack;
+  if (typeof stack === 'string') {
+    for (const line of stack.split('\n')) {
+      const match = line.match(/(?:\(|\s)(file:\/\/[\S]+|\/[\S]+):\d+:\d+/);
+      if (match?.[1]) {
+        const potentialPath = match[1];
+        return potentialPath.startsWith('file://')
+          ? fileURLToPath(potentialPath)
+          : potentialPath;
+      }
+    }
+  }
+
+  throw new Error('Unable to determine the current module path.');
+})();
 const isTsEnv = currentFile.endsWith('.ts');
 const rootDir = isTsEnv ? 'src' : 'dist';
 const fileExtension = isTsEnv ? 'ts' : 'js';


### PR DESCRIPTION
## Summary
- prefer Node-provided `__filename`/`module.filename` when available to detect the active module path
- fall back to an `import.meta.url` lookup guarded by `eval` and a stack-trace parser so CommonJS builds can resolve the path safely

## Testing
- npm run start
- npm run typeorm:migration:run

------
https://chatgpt.com/codex/tasks/task_e_68dc39ba323083218a7d1d5a178eefdb